### PR TITLE
fix: suppress ugettext_lazy Deprecated Warning

### DIFF
--- a/drf_problems/exceptions.py
+++ b/drf_problems/exceptions.py
@@ -3,7 +3,7 @@ import logging
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.reverse import reverse
 from rest_framework.views import exception_handler as drf_exception_handler


### PR DESCRIPTION
When I run tests, this warning came out.

```
/usr/local/lib/python3.8/site-packages/drf_problems/exceptions.py:74:

RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

A future version will drop support for ugettext_lazy() in favor of gettext_lazy(). 

Deprecation announcement in [Django 3.0 release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/#id3)

